### PR TITLE
Update references to GitHub repo which has been moved

### DIFF
--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -53,7 +53,7 @@ jobs:
         include:
         - os: 'ubuntu-latest'
           java: '17'
-          canonical: ${{ (github.repository == 'eclipse/transformer') && ((github.ref == 'refs/heads/main') || (github.ref == 'refs/heads/release')) && (github.event_name != 'pull_request') }}
+          canonical: ${{ (github.repository_owner == 'eclipse-transformer') && ((github.ref == 'refs/heads/main') || (github.ref == 'refs/heads/release')) && (github.event_name != 'pull_request') }}
         - os: 'ubuntu-latest'
           java: '17'
           experimental: true

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -48,7 +48,7 @@ jobs:
           Given the limited bandwidth of the team, it will be automatically closed if no further
           activity occurs.
           If you feel this is something you could contribute, please have a look
-          at our [Contributor Guide](https://github.com/eclipse/transformer/blob/main/CONTRIBUTING.md).
+          at our [Contributor Guide](https://github.com/eclipse-transformer/transformer/blob/main/CONTRIBUTING.md).
           Thank you for your contribution.
         close-issue-message: >
           This issue has been automatically closed due to inactivity. If you can reproduce this or

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ feels wrong or incomplete.
 
 ## Reporting Issues
 
-Issues can be reported in [the GitHub issue tracker](https://github.com/eclipse/transformer/issues).
+Issues can be reported in [the GitHub issue tracker](https://github.com/eclipse-transformer/transformer/issues).
 Please include the steps required to reproduce the problem if possible and applicable.
 This information will help us review and fix your issue faster.
 
@@ -18,14 +18,14 @@ You can use your system `mvn` but we require a recent version.
 
 - `./mvnw clean install` - Assembles and tests the project
 
-We use [GitHub Actions](https://github.com/eclipse/transformer/actions?query=workflow%3A%22CI%20Build%22) and the repo includes a
+We use [GitHub Actions](https://github.com/eclipse-transformer/transformer/actions?query=workflow%3A%22CI%20Build%22) and the repo includes a
 `.github/workflows/cibuild.yml` file to build with GitHub Actions.
 
 ## Workflow
 
 We use [git triangular workflow](https://github.blog/2015-07-29-git-2-5-including-multiple-worktrees-and-triangular-workflows/).
-This means that no one, not even the maintainers, push contributions directly into the [main repo](https://github.com/eclipse/transformer). All contribution come in through pull requests.
-So each contributor will need to [fork the main repo](https://github.com/eclipse/transformer/fork)
+This means that no one, not even the maintainers, push contributions directly into the [main repo](https://github.com/eclipse-transformer/transformer). All contribution come in through pull requests.
+So each contributor will need to [fork the main repo](https://github.com/eclipse-transformer/transformer/fork)
 on GitHub. All contributions are made as commits to your fork. Then you submit a
 pull request to have them considered for merging into the main repo.
 
@@ -33,7 +33,7 @@ pull request to have them considered for merging into the main repo.
 
 After forking the main repo on GitHub, you can clone the main repo to your system:
 
-    git clone https://github.com/eclipse/transformer.git
+    git clone https://github.com/eclipse-transformer/transformer.git
 
 This will clone the main repo to a local repo on your disk and set up the `origin` remote in Git.
 Next you will set up the second side of the triangle to your fork repo.
@@ -71,7 +71,7 @@ received feedback on what to improve.
 ### Create issues
 
 Any significant improvement should be documented as [a GitHub
-issue](https://github.com/eclipse/transformer/issues) before anybody
+issue](https://github.com/eclipse-transformer/transformer/issues) before anybody
 starts working on it.
 
 ### ... but check for existing issues first

--- a/INFRA.md
+++ b/INFRA.md
@@ -4,7 +4,7 @@
 
 The Eclipse Transformer is stored in a standard Git repository, hosted under the Eclipse Foundation GIT organization:
 
-  [https://github.com/eclipse/transformer]
+  [https://github.com/eclipse-transformer/transformer]
 
 Build scripts and standard files are located at the root:
 

--- a/NOTICE
+++ b/NOTICE
@@ -27,4 +27,4 @@ SPDX-License-Identifier: (EPL-2.0 OR Apache-2.0)
 
 The project maintains the following source code repositories:
 
- * https://github.com/eclipse/transformer.git
+ * https://github.com/eclipse-transformer/transformer.git

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ We operate under the [Eclipse Code of Conduct](https://eclipse.org/org/documents
 
 ## Build Status
 
-[![CI Build](https://github.com/eclipse/transformer/actions/workflows/cibuild.yml/badge.svg)](https://github.com/eclipse/transformer/actions/workflows/cibuild.yml)
+[![CI Build](https://github.com/eclipse-transformer/transformer/actions/workflows/cibuild.yml/badge.svg)](https://github.com/eclipse-transformer/transformer/actions/workflows/cibuild.yml)
 
 ## Latest release
 

--- a/bnd-plugins/org.eclipse.transformer.bnd.analyzer/pom.xml
+++ b/bnd-plugins/org.eclipse.transformer.bnd.analyzer/pom.xml
@@ -26,9 +26,9 @@
 	<name>${project.groupId}:${project.artifactId}</name>
 	<url>https://projects.eclipse.org/projects/technology.transformer</url>
 	<scm>
-		<url>https://github.com/eclipse/transformer</url>
-		<connection>scm:git:https://github.com/eclipse/transformer.git</connection>
-		<developerConnection>scm:git:git@github.com:eclipse/transformer.git</developerConnection>
+		<url>https://github.com/eclipse-transformer/transformer</url>
+		<connection>scm:git:https://github.com/eclipse-transformer/transformer.git</connection>
+		<developerConnection>scm:git:git@github.com:eclipse-transformer/transformer.git</developerConnection>
 		<tag>${revision}</tag>
 	</scm>
 

--- a/maven-plugins/transformer-maven-plugin/pom.xml
+++ b/maven-plugins/transformer-maven-plugin/pom.xml
@@ -26,9 +26,9 @@
 	<packaging>maven-plugin</packaging>
 	<url>https://projects.eclipse.org/projects/technology.transformer</url>
 	<scm>
-		<url>https://github.com/eclipse/transformer</url>
-		<connection>scm:git:https://github.com/eclipse/transformer.git</connection>
-		<developerConnection>scm:git:git@github.com:eclipse/transformer.git</developerConnection>
+		<url>https://github.com/eclipse-transformer/transformer</url>
+		<connection>scm:git:https://github.com/eclipse-transformer/transformer.git</connection>
+		<developerConnection>scm:git:git@github.com:eclipse-transformer/transformer.git</developerConnection>
 		<tag>${revision}</tag>
 	</scm>
 

--- a/org.eclipse.transformer.cli/pom.xml
+++ b/org.eclipse.transformer.cli/pom.xml
@@ -26,9 +26,9 @@
 	<name>${project.groupId}:${project.artifactId}</name>
 	<url>https://projects.eclipse.org/projects/technology.transformer</url>
 	<scm>
-		<url>https://github.com/eclipse/transformer</url>
-		<connection>scm:git:https://github.com/eclipse/transformer.git</connection>
-		<developerConnection>scm:git:git@github.com:eclipse/transformer.git</developerConnection>
+		<url>https://github.com/eclipse-transformer/transformer</url>
+		<connection>scm:git:https://github.com/eclipse-transformer/transformer.git</connection>
+		<developerConnection>scm:git:git@github.com:eclipse-transformer/transformer.git</developerConnection>
 		<tag>${revision}</tag>
 	</scm>
 

--- a/org.eclipse.transformer.jakarta/pom.xml
+++ b/org.eclipse.transformer.jakarta/pom.xml
@@ -26,9 +26,9 @@
 	<name>${project.groupId}:${project.artifactId}</name>
 	<url>https://projects.eclipse.org/projects/technology.transformer</url>
 	<scm>
-		<url>https://github.com/eclipse/transformer</url>
-		<connection>scm:git:https://github.com/eclipse/transformer.git</connection>
-		<developerConnection>scm:git:git@github.com:eclipse/transformer.git</developerConnection>
+		<url>https://github.com/eclipse-transformer/transformer</url>
+		<connection>scm:git:https://github.com/eclipse-transformer/transformer.git</connection>
+		<developerConnection>scm:git:git@github.com:eclipse-transformer/transformer.git</developerConnection>
 		<tag>${revision}</tag>
 	</scm>
 

--- a/org.eclipse.transformer.parent/pom.xml
+++ b/org.eclipse.transformer.parent/pom.xml
@@ -52,9 +52,9 @@
 		</license>
 	</licenses>
 	<scm>
-		<url>https://github.com/eclipse/transformer</url>
-		<connection>scm:git:https://github.com/eclipse/transformer.git</connection>
-		<developerConnection>scm:git:git@github.com:eclipse/transformer.git</developerConnection>
+		<url>https://github.com/eclipse-transformer/transformer</url>
+		<connection>scm:git:https://github.com/eclipse-transformer/transformer.git</connection>
+		<developerConnection>scm:git:git@github.com:eclipse-transformer/transformer.git</developerConnection>
 		<tag>${revision}</tag>
 	</scm>
 	<developers>
@@ -73,7 +73,7 @@
 	</developers>
 	<issueManagement>
 		<system>GitHub Issues</system>
-		<url>https://github.com/eclipse/transformer/issues</url>
+		<url>https://github.com/eclipse-transformer/transformer/issues</url>
 	</issueManagement>
 	<mailingLists>
 		<mailingList>

--- a/org.eclipse.transformer/pom.xml
+++ b/org.eclipse.transformer/pom.xml
@@ -26,9 +26,9 @@
 	<name>${project.groupId}:${project.artifactId}</name>
 	<url>https://projects.eclipse.org/projects/technology.transformer</url>
 	<scm>
-		<url>https://github.com/eclipse/transformer</url>
-		<connection>scm:git:https://github.com/eclipse/transformer.git</connection>
-		<developerConnection>scm:git:git@github.com:eclipse/transformer.git</developerConnection>
+		<url>https://github.com/eclipse-transformer/transformer</url>
+		<connection>scm:git:https://github.com/eclipse-transformer/transformer.git</connection>
+		<developerConnection>scm:git:git@github.com:eclipse-transformer/transformer.git</developerConnection>
 		<tag>${revision}</tag>
 	</scm>
 

--- a/org.eclipse.transformer/src/main/java/org/eclipse/transformer/AppOption.java
+++ b/org.eclipse.transformer/src/main/java/org/eclipse/transformer/AppOption.java
@@ -58,7 +58,7 @@ public enum AppOption {
 		Settings.HAS_ARG_COUNT, 3, !Settings.IS_REQUIRED, Settings.NO_GROUP)),
 
 	// Issue #154: Enable processing of JARs within JARs. See:
-	// https://github.com/eclipse/transformer/issues/154
+	// https://github.com/eclipse-transformer/transformer/issues/154
 	//
 	// By default, archive nesting is restricted to JavaEE active locations.
 	// This may be relaxed to enable JAR and ZIP within JAR, ZIP within ZIP,


### PR DESCRIPTION
Eclipse moved the transformer repo to a new GitHub organization. See https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/5325