### PR TITLE
Update build for migration to Central Portal

### DIFF
--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -86,16 +86,16 @@ jobs:
       with:
         distribution: 'temurin'
         java-version: ${{ matrix.java }}
-        server-id: ossrh
-        server-username: OSSRH_USERNAME
-        server-password: OSSRH_TOKEN
+        server-id: central
+        server-username: CENTRAL_USERNAME
+        server-password: CENTRAL_PASSWORD
         gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
         gpg-passphrase: GPG_PASSPHRASE
     - name: Publish
       if: ${{ matrix.canonical }}
       run: |
-        ./.github/scripts/publish.sh -Possrh
+        ./.github/scripts/publish.sh -Pcentral
       env:
         GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
-        OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-        OSSRH_TOKEN: ${{ secrets.OSSRH_TOKEN }}
+        CENTRAL_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+        CENTRAL_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}

--- a/README.md
+++ b/README.md
@@ -163,34 +163,40 @@ Immediate options may be used with or without specifying a corresponding propert
 
 The Eclipse Transformer artifacts are released to Maven Central.
 
-Snapshot artifacts are released to the Sonatype OSS repository: [https://oss.sonatype.org/content/repositories/snapshots/](https://oss.sonatype.org/content/repositories/snapshots/org/eclipse/transformer/).
+Snapshot artifacts are released to the Central Portal snapshot repository: [https://central.sonatype.com/repository/maven-snapshots/](https://central.sonatype.com/repository/maven-snapshots/org/eclipse/transformer/).
 
-To use the snapshot artifacts in your Maven build, you can configure the Sonatype OSS snapshot repository.
+To use the snapshot artifacts in your Maven build, you can configure the Central Portal snapshot repository.
 
 ```xml
 <repositories>
     <repository>
-        <id>ossrh</id>
-        <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
-        <layout>default</layout>
+        <name>Central Portal Snapshots</name>
+        <id>central-portal-snapshots</id>
+        <url>https://central.sonatype.com/repository/maven-snapshots/</url>
         <releases>
             <enabled>false</enabled>
         </releases>
+        <snapshots>
+            <enabled>true</enabled>
+        </snapshots>
     </repository>
 </repositories>
 ```
 
-To use the snapshot transformer maven plugin in your Maven build, you can configure the Sonatype OSS snapshot repository.
+To use the snapshot transformer maven plugin in your Maven build, you can configure the Central Portal snapshot repository.
 
 ```xml
 <pluginRepositories>
     <pluginRepository>
-        <id>ossrh</id>
-        <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
-        <layout>default</layout>
+        <name>Central Portal Snapshots</name>
+        <id>central-portal-snapshots</id>
+        <url>https://central.sonatype.com/repository/maven-snapshots/</url>
         <releases>
             <enabled>false</enabled>
         </releases>
+        <snapshots>
+            <enabled>true</enabled>
+        </snapshots>
     </pluginRepository>
 </pluginRepositories>
 ```

--- a/org.eclipse.transformer.parent/pom.xml
+++ b/org.eclipse.transformer.parent/pom.xml
@@ -222,9 +222,9 @@ SPDX-License-Identifier: ${project.licenses[0].name}
 					</executions>
 				</plugin>
 				<plugin>
-					<groupId>org.sonatype.plugins</groupId>
-					<artifactId>nexus-staging-maven-plugin</artifactId>
-					<version>1.7.0</version>
+					<groupId>org.sonatype.central</groupId>
+					<artifactId>central-publishing-maven-plugin</artifactId>
+					<version>0.7.0</version>
 					<extensions>true</extensions>
 				</plugin>
 				<plugin>
@@ -616,7 +616,7 @@ SPDX-License-Identifier: ${project.licenses[0].name}
 			</properties>
 		</profile>
 		<profile>
-			<id>ossrh</id>
+			<id>central</id>
 			<properties>
 				<skipTests>true</skipTests>
 				<maven.test.skip>true</maven.test.skip>
@@ -635,21 +635,14 @@ SPDX-License-Identifier: ${project.licenses[0].name}
 						</configuration>
 					</plugin>
 					<plugin>
-						<groupId>org.sonatype.plugins</groupId>
-						<artifactId>nexus-staging-maven-plugin</artifactId>
+						<groupId>org.sonatype.central</groupId>
+						<artifactId>central-publishing-maven-plugin</artifactId>
 						<configuration>
-							<serverId>ossrh</serverId>
-							<nexusUrl>https://oss.sonatype.org/</nexusUrl>
+							<publishingServerId>central</publishingServerId>
 						</configuration>
 					</plugin>
 				</plugins>
 			</build>
-			<distributionManagement>
-				<snapshotRepository>
-					<id>ossrh</id>
-					<url>https://oss.sonatype.org/content/repositories/snapshots/</url>
-				</snapshotRepository>
-			</distributionManagement>
 		</profile>
 		<profile>
 			<id>bnd-snapshot</id>


### PR DESCRIPTION
See
https://central.sonatype.org/faq/what-is-different-between-central-portal-and-legacy-ossrh/#self-service-migration and
https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/6146