### PR TITLE
Eclipse Foundation changed secret names

### DIFF
--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -97,5 +97,5 @@ jobs:
         ./.github/scripts/publish.sh -Pcentral
       env:
         GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
-        CENTRAL_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-        CENTRAL_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
+        CENTRAL_USERNAME: ${{ secrets.CENTRAL_SONATYPE_TOKEN_USERNAME }}
+        CENTRAL_PASSWORD: ${{ secrets.CENTRAL_SONATYPE_TOKEN_PASSWORD }}


### PR DESCRIPTION
This fixes the build break.